### PR TITLE
updating syntax to use 'AfterSuccess' instead of 'After' due to depre…

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -9,7 +9,7 @@ def component = "jordanhoey96-nodejs"
 def yarnBuilder = new uk.gov.hmcts.contino.YarnBuilder(this)
 
 withPipeline(type, product, component) {
-  after('build') {
+  afterSuccess('build') {
     yarnBuilder.yarn('rebuild puppeteer')
     yarnBuilder.yarn('build')
   }

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -12,7 +12,7 @@ def product = "labs"
 def component = "jordanhoey96-nodejs"
 
 withNightlyPipeline(type, product, component) {
-  after('build') {
+  afterSucess('build') {
     yarnBuilder.yarn('build')
   }
 }

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -13,7 +13,7 @@ def component = "jordanhoey96-nodejs"
 def yarnBuilder = new uk.gov.hmcts.contino.YarnBuilder(this)
 
 withPipeline(type, product, component) {
-  after('build') {
+  afterSuccess('build') {
     yarnBuilder.yarn('build')
   }
 }


### PR DESCRIPTION
### Change description ###

After('build') has been deprecated, replacing with AfterSuccess('build')

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
